### PR TITLE
add additional output threads, bump resources

### DIFF
--- a/manifests/splunk-kubernetes-logging/configMap.yaml
+++ b/manifests/splunk-kubernetes-logging/configMap.yaml
@@ -342,10 +342,11 @@ data:
           @type memory
           chunk_limit_records 100000
           chunk_limit_size 200m
-          flush_interval 5s
-          flush_thread_count 1
+          flush_interval 2s
+          flush_thread_count 8
           overflow_action block
           retry_max_times 3
+          retry_forever true
           total_limit_size 600m
         </buffer>
         <format monitor_agent>

--- a/manifests/splunk-kubernetes-logging/daemonset.yaml
+++ b/manifests/splunk-kubernetes-logging/daemonset.yaml
@@ -55,8 +55,8 @@ spec:
               key: splunk_hec_token
         resources:
           requests:
-            cpu: 100m
-            memory: 200Mi
+            cpu: 500m
+            memory: 512Mi
         volumeMounts:
         - name: varlog
           mountPath: "/var/log"

--- a/manifests/splunk-kubernetes-logging/daemonset.yaml
+++ b/manifests/splunk-kubernetes-logging/daemonset.yaml
@@ -55,8 +55,8 @@ spec:
               key: splunk_hec_token
         resources:
           requests:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 100m
+            memory: 200Mi
         volumeMounts:
         - name: varlog
           mountPath: "/var/log"


### PR DESCRIPTION
## Proposed changes
Adds more threads for sending to Splunk HEC endpoints (from 1 to 8).  This should make the output buffer overflow condition much less likely.  Also added additional compute and memory resources to account for the higher number of simultaneous threads.
Reduced the amount of time in-between buffer flushes as well.  It's unlikely that it's flushing based on time at the current velocity (and is instead flushing when it hits a high percentage of `chunk_limit_records`).  But nevertheless, more flushing can help when you have the threads to handle it.
Additional parameter added of `retry_forever` to prevent log loss in the event the HEC endpoint is unavailable for a length of time.  Fluentd will exponentially back off retries, so when HEC is available again, the agent won't send a flood of retried events instantaneously.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

